### PR TITLE
Skip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +358,7 @@ name = "link-checker"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "regex",
  "scraper",
  "serde",
  "serde_json",
@@ -400,6 +410,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
@@ -550,6 +566,35 @@ checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ scraper = "0.24"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+regex = "1.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A generic web link checker tool that crawls a website and validates all links wi
 ## installation
 
 ```
-curl -sSL https://raw.githubusercontent.com/A2-ai/rv/refs/heads/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/A2-ai/link-checker/refs/heads/main/scripts/install.sh | bash
 ```
 
 or for mac can also:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,12 +246,12 @@ log_verbose "=== DOWNLOAD AND INSTALLATION ==="
 log_verbose "Download URL: $asset_url"
 
 # Download the asset using curl, extract it, clean up, and make executable
-echo "Downloading rv from $asset_url"
-curl -L -o rv_latest.tar.gz "$asset_url" &&
-    tar -xzf rv_latest.tar.gz &&
-    rm rv_latest.tar.gz &&
-    chmod +x rv &&
-    echo "rv installed successfully to ~/.local/bin" ||
+echo "Downloading link-checker from $asset_url"
+curl -L -o link-checker_latest.tar.gz "$asset_url" &&
+    tar -xzf link-checker_latest.tar.gz &&
+    rm link-checker_latest.tar.gz &&
+    chmod +x link-checker &&
+    echo "link-checker installed successfully to ~/.local/bin" ||
     (echo "Installation failed." >&2 && exit 1)
 
 log_verbose "Installation completed successfully"


### PR DESCRIPTION
Checking versioned docs site

```
link-checker --url http://localhost:3000/cqtkit-docs/versions/dev/ 
```
Reveals one external broken link:
```
...
Got crawling error: bad http response: 403 for URL https://ascpt.onlinelibrary.wiley.com/doi/10.1038/clpt.2014.155
Crawled 136 pages, checked 500 unique URLs, found 1 broken link.

Broken links:
  - https://ascpt.onlinelibrary.wiley.com/doi/10.1038/clpt.2014.155 (found on: http://localhost:3000/cqtkit-docs/versions/dev/reference/data/datasets/)

Crawling completed in 1.321076291s
```
adding it as a regex pattern with `--skip`

```
link-checker --url http://localhost:3000/cqtkit-docs/versions/dev --skip "https://ascpt.*"
```
no broken links
```
...
Skipping broken link (matches skip pattern): https://ascpt.onlinelibrary.wiley.com/doi/10.1038/clpt.2014.155
Crawled 137 pages, checked 501 unique URLs, found no broken links.

Crawling completed in 1.457846958s
```

During testing this link would sometimes report as not broken, and it works in the site - no skipped links here for the same command.
```
Crawled 138 pages, checked 501 unique URLs, found no broken links.

Crawling completed in 1.30992575s
```

Additionally, this PR fixes some rv references in the installation instructions in README and in the install.sh script itself.